### PR TITLE
Feature ::: Launch App from Push Notification Click

### DIFF
--- a/www/OSFirebaseCloudMessaging.js
+++ b/www/OSFirebaseCloudMessaging.js
@@ -91,6 +91,56 @@ exports._listener = {};
 };
 
 /**
+ * Create a callback function to get executed within a specific scope.
+ *
+ * @param [ Function ] fn    The function to be exec as the callback.
+ * @param [ Object ]   scope The callback function's scope.
+ *
+ * @return [ Function ]
+ */
+exports._createCallbackFn = function (fn, scope) {
+
+    if (typeof fn != 'function')
+        return;
+
+    return function () {
+        fn.apply(scope || this, arguments);
+    };
+};
+
+/**
+ * Execute the native counterpart.
+ *
+ * @param [ String ]  action   The name of the action.
+ * @param [ Array ]   args     Array of arguments.
+ * @param [ Function] callback The callback function.
+ * @param [ Object ] scope     The scope for the function.
+ *
+ * @return [ Void ]
+ */
+exports._exec = function (action, args, callback, scope) {
+    var fn     = this._createCallbackFn(callback, scope),
+        params = [];
+
+    if (Array.isArray(args)) {
+        params = args;
+    } else if (args !== null) {
+        params.push(args);
+    }
+
+    exec(fn, null, 'OSFirebaseCloudMessaging', action, params);
+};
+
+/**
+ * Fire queued events once the device is ready and all listeners are registered.
+ *
+ * @return [ Void ]
+ */
+exports.fireQueuedEvents = function() {
+    exports._exec('ready');
+};
+
+/**
  * Fire the event with given arguments.
  *
  * @param [ String ] event The event's name.


### PR DESCRIPTION
## Description
Add 'deviceReady' method. By controlling its triggering, we can timely trigger an event fired by clicking a push notification when the app is closed.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-1605
https://outsystemsrd.atlassian.net/browse/RMET-1606

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [x] JavaScript

## Checklist
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
