### PR TITLE
RMET-1743 ::: Classes renamed to avoid incompatibility issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Released]
 
+## 28-07-2022
+- Renamed classes to avoid incompatibility. (https://outsystemsrd.atlassian.net/browse/RMET-1743)
+
 ## 26-07-2022
 - Added dependency on external libs. Changed methods to sync. (https://outsystemsrd.atlassian.net/browse/RMET-1480)
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -43,8 +43,8 @@
     <source-file src="src/ios/Managers/MessagingManager.swift" />
     <source-file src="src/ios/Managers/NotificationManager.swift" />
 
-    <source-file src="src/ios/Model/OSExtraData.swift" />
-    <source-file src="src/ios/Model/OSNotification.swift" />
+    <source-file src="src/ios/Model/OSFCMExtraData.swift" />
+    <source-file src="src/ios/Model/OSFCMNotification.swift" />
 
     <source-file src="src/ios/Protocols/FirebaseMessagingProtocol.swift" />
     <source-file src="src/ios/Protocols/MessagingProtocol.swift" />

--- a/src/ios/CoreDataManager/NotificationsModel.xcdatamodeld/.xccurrentversion
+++ b/src/ios/CoreDataManager/NotificationsModel.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>NotificationsModel 2.xcdatamodel</string>
+</dict>
+</plist>

--- a/src/ios/CoreDataManager/NotificationsModel.xcdatamodeld/NotificationsModel 2.xcdatamodel/contents
+++ b/src/ios/CoreDataManager/NotificationsModel.xcdatamodeld/NotificationsModel 2.xcdatamodel/contents
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="NotificationsModel">
+    <entity name="OSFCMExtraData" representedClassName="OSFCMExtraData" syncable="YES" codeGenerationType="category">
+        <attribute name="key" optional="YES" attributeType="String"/>
+        <attribute name="value" optional="YES" attributeType="String"/>
+        <relationship name="notification" maxCount="1" deletionRule="Nullify" destinationEntity="OSFCMNotification" inverseName="extraDataList" inverseEntity="OSFCMNotification"/>
+    </entity>
+    <entity name="OSFCMNotification" representedClassName="OSFCMNotification" syncable="YES" codeGenerationType="category">
+        <attribute name="messageID" attributeType="String"/>
+        <attribute name="timeStamp" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="timeToLive" attributeType="String"/>
+        <relationship name="extraDataList" toMany="YES" deletionRule="Cascade" destinationEntity="OSFCMExtraData" inverseName="notification" inverseEntity="OSFCMExtraData"/>
+    </entity>
+    <elements>
+        <element name="OSFCMExtraData" positionX="-63" positionY="9" width="128" height="74"/>
+        <element name="OSFCMNotification" positionX="-63" positionY="-18" width="128" height="89"/>
+    </elements>
+</model>

--- a/src/ios/FirebaseMessagingApplicationDelegate.swift
+++ b/src/ios/FirebaseMessagingApplicationDelegate.swift
@@ -250,10 +250,10 @@ extension FirebaseMessagingApplicationDelegate {
            let extraData = userInfo[JSONKeys.extraDataList] as? [NotificationDictionary] {
             
             let notificationDict: [String: Any] = [
-                OSNotification.CodingKeys.messageID.rawValue: messageID,
-                OSNotification.CodingKeys.timeToLive.rawValue: timeToLive,
-                OSNotification.CodingKeys.extraDataList.rawValue: extraData,
-                OSNotification.CodingKeys.timeStamp.rawValue: Date().millisecondsSince1970
+                OSFCMNotification.CodingKeys.messageID.rawValue: messageID,
+                OSFCMNotification.CodingKeys.timeToLive.rawValue: timeToLive,
+                OSFCMNotification.CodingKeys.extraDataList.rawValue: extraData,
+                OSFCMNotification.CodingKeys.timeStamp.rawValue: Date().millisecondsSince1970
             ]
             _ = notificationManager.insertNotification(notificationDict: notificationDict)
         }

--- a/src/ios/Managers/NotificationManager.swift
+++ b/src/ios/Managers/NotificationManager.swift
@@ -11,7 +11,7 @@ public protocol NotificationManagerProtocol {
     
     /// Fetches the store notifications on Core Data.
     /// - Returns: An array of notifications or an error, in case of failure.
-    func fetchNotifications() -> Result<[OSNotification], Error>
+    func fetchNotifications() -> Result<[OSFCMNotification], Error>
     
     /// Sends a local notification on to the Notification Center.
     /// - Parameters:
@@ -65,8 +65,8 @@ public final class NotificationManager: NSObject {
     /// Deletes all notifications provided by input from Core Data manager.
     /// - Parameter notifications: Notifications to remove.
     /// - Returns: A boolean indicating the success of the operation or an error, in case of failure.
-    public func deletePendingNotifications(_ notifications: [OSNotification]) -> Result<Bool, Error> {
-        let fetchRequest: NSFetchRequest<OSNotification> = OSNotification.fetchRequest()
+    public func deletePendingNotifications(_ notifications: [OSFCMNotification]) -> Result<Bool, Error> {
+        let fetchRequest: NSFetchRequest<OSFCMNotification> = OSFCMNotification.fetchRequest()
         do {
             let fetchRequestResults = try self.coreDataManager.fetch(fetchRequest)
             let filtered = fetchRequestResults.filter({ notifications.contains($0) })
@@ -119,7 +119,7 @@ extension NotificationManager: NotificationManagerProtocol {
         decoder.userInfo[CodingUserInfoKey.managedObjectContext] = self.coreDataManager.context()
         do {
             let notificationData = try JSONSerialization.data(withJSONObject: notificationDict)
-            _ = try decoder.decode(OSNotification.self, from: notificationData)
+            _ = try decoder.decode(OSFCMNotification.self, from: notificationData)
             
             try self.coreDataManager.saveContext()
         } catch {
@@ -131,8 +131,8 @@ extension NotificationManager: NotificationManagerProtocol {
     
     /// Fetches the store notifications on Core Data.
     /// - Returns: An array of notifications or an error, in case of failure.
-    public func fetchNotifications() -> Result<[OSNotification], Error> {
-        let fetchRequest: NSFetchRequest<OSNotification> = OSNotification.fetchRequest()
+    public func fetchNotifications() -> Result<[OSFCMNotification], Error> {
+        let fetchRequest: NSFetchRequest<OSFCMNotification> = OSFCMNotification.fetchRequest()
         do {
             let notifications = try self.coreDataManager.fetch(fetchRequest)
             return .success(notifications)            

--- a/src/ios/Model/OSFCMExtraData.swift
+++ b/src/ios/Model/OSFCMExtraData.swift
@@ -1,8 +1,8 @@
 import CoreData
 
 /// Core Data Model that stores the dynamic properties associated with a specific Notification.
-@objc(OSExtraData)
-public class OSExtraData: NSManagedObject, Codable {
+@objc(OSFCMExtraData)
+public class OSFCMExtraData: NSManagedObject, Codable {
     
     /// Constructor method inherited from `NSManagedObject`.
     /// - Parameters:
@@ -20,7 +20,7 @@ public class OSExtraData: NSManagedObject, Codable {
     init(key: String,
          value: String,
          context: NSManagedObjectContext) {
-        super.init(entity: NSEntityDescription.entity(forEntityName: "OSExtraData", in: context)!, insertInto: context)
+        super.init(entity: NSEntityDescription.entity(forEntityName: "OSFCMExtraData", in: context)!, insertInto: context)
         self.key = key
         self.value = value
     }

--- a/src/ios/Model/OSFCMNotification.swift
+++ b/src/ios/Model/OSFCMNotification.swift
@@ -1,8 +1,8 @@
 import CoreData
 
 /// Core Data Model that stores the properties associated with a Notification.
-@objc(OSNotification)
-public class OSNotification: NSManagedObject, Codable {
+@objc(OSFCMNotification)
+public class OSFCMNotification: NSManagedObject, Codable {
     
     /// Constructor method inherited from `NSManagedObject`.
     /// - Parameters:
@@ -20,11 +20,11 @@ public class OSNotification: NSManagedObject, Codable {
     ///   - timeStamp: Numeric representation of the creation datetime,
     ///   - context: An object space to manipulate and track changes to managed objects.
     init(messageID: String,
-         extraDataList: [OSExtraData],
+         extraDataList: [OSFCMExtraData],
          timeToLive: String,
          timeStamp: Double,
          context: NSManagedObjectContext) {
-        super.init(entity: NSEntityDescription.entity(forEntityName: "OSNotification", in: context)!, insertInto: context)
+        super.init(entity: NSEntityDescription.entity(forEntityName: "OSFCMNotification", in: context)!, insertInto: context)
         self.messageID = messageID
         self.extraDataList = NSSet(array: extraDataList)
         self.timeToLive = timeToLive
@@ -41,7 +41,7 @@ public class OSNotification: NSManagedObject, Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(messageID, forKey: .messageID)
-        try container.encode(extraDataList?.allObjects as? [OSExtraData], forKey: .extraDataList)
+        try container.encode(extraDataList?.allObjects as? [OSFCMExtraData], forKey: .extraDataList)
         try container.encode(timeToLive, forKey: .timeToLive)
         try container.encode(timeStamp, forKey: .timeStamp)
     }
@@ -55,7 +55,7 @@ public class OSNotification: NSManagedObject, Codable {
         
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let messageID = try container.decode(String.self, forKey: .messageID)
-        let extraDataList = try container.decode([OSExtraData].self, forKey: .extraDataList)
+        let extraDataList = try container.decode([OSFCMExtraData].self, forKey: .extraDataList)
         let timeToLive = try container.decode(String.self, forKey: .timeToLive)
         let timeStamp = try container.decode(Double.self, forKey: .timeStamp)
         self.init(messageID: messageID, extraDataList: extraDataList, timeToLive: timeToLive, timeStamp: timeStamp, context: context)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Classes _OSNotification_ and _OSExtraData_ renamed to _OSFCMNotification_  and _OSFCMExtraData_ to avoid incompatibility issues.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
