### PR TITLE
RMET-1709 :: Permission request for android 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 20-09-2022
+- Added permission request to receive notifications on Android API >= 33.
+
 ## [Version 1.0.2]
 
 ## 28-07-2022

--- a/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
+++ b/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
@@ -22,9 +22,10 @@ repositories {
 apply plugin: 'kotlin-kapt'
 
 dependencies {
-    implementation("com.github.outsystems:oscore-android:1.1.0@aar")
-    implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
+    implementation("com.github.outsystems:oscore-android:1.2.0@aar")
+    implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
     implementation("com.github.outsystems:osfirebasemessaging-android:0.0.3@aar")
+    implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
 
     implementation("com.google.code.gson:gson:2.8.9")
 


### PR DESCRIPTION
## Description
- This PR adds a permission request to receive notifications when targeting Android Api >= 33

## Context
[<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->](https://outsystemsrd.atlassian.net/browse/RMET-1709)

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests
Tested on Android simulators api 32 and 33.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
