### PR TITLE
RMET-2054 ::: iOS ::: Get APNs Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ The changes documented here do not include those from the original repository.
 ## [Unreleased]
 
 ### 16-12-2022
+- Feat: [iOS] Update iOS lib files in order to include the new Get APNs Token method (https://outsystemsrd.atlassian.net/browse/RMET-2054).
 - Replaced jcenter with more up to date mavenCentral [RMET-2036](https://outsystemsrd.atlassian.net/browse/RMET-2036)
 
-### 2022-11-10
+### 10-11-2022
 - Use fixed versions (https://outsystemsrd.atlassian.net/browse/RMET-2045).
 
 ## [Version 1.0.5]

--- a/plugin.xml
+++ b/plugin.xml
@@ -53,6 +53,7 @@
     <source-file src="src/ios/Utils/FirebaseConfigurations.swift" />
     <source-file src="src/ios/Utils/FirebaseMessagingErrors.swift" />
     <source-file src="src/ios/Utils/FirebaseNotificationEventType.swift" />
+    <source-file src="src/ios/Utils/OSFCMTokenType.swift" />
 
     <source-file src="src/ios/FirebaseMessagingApplicationDelegate.swift" />
     <source-file src="src/ios/FirebaseMessagingController.swift" />
@@ -68,7 +69,7 @@
             <source url="https://cdn.cocoapods.org/"/>
         </config>
         <pods use-frameworks="true">
-            <pod name="Firebase/Messaging" spec="~> 8.6.0" />
+            <pod name="Firebase/Messaging" spec="8.6.1" />
             <pod name="OSCommonPluginLib" spec="1.0.0" />
         </pods>
     </podspec>

--- a/src/ios/AppDelegate+OSFirebaseCloudMessaging.m
+++ b/src/ios/AppDelegate+OSFirebaseCloudMessaging.m
@@ -8,6 +8,14 @@
     Method original = class_getInstanceMethod(self, @selector(application:didFinishLaunchingWithOptions:));
     Method swizzled = class_getInstanceMethod(self, @selector(application:firebaseCloudMessagingPluginDidFinishLaunchingWithOptions:));
     method_exchangeImplementations(original, swizzled);
+    
+    original = class_getInstanceMethod(self, @selector(application:didReceiveRemoteNotification:fetchCompletionHandler:));
+    swizzled = class_getInstanceMethod(self, @selector(application:firebaseCloudMessagingDidReceiveRemoteNotification:fetchCompletionHandler:));
+    method_exchangeImplementations(original, swizzled);
+    
+    original = class_getInstanceMethod(self, @selector(application:didRegisterForRemoteNotificationsWithDeviceToken:));
+    swizzled = class_getInstanceMethod(self, @selector(application:firebaseCloudMessagingdidRegisterForRemoteNotificationsWithDeviceToken:));
+    method_exchangeImplementations(original, swizzled);
 }
 
 - (BOOL)application:(UIApplication *)application firebaseCloudMessagingPluginDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
@@ -18,8 +26,16 @@
     return YES;
 }
 
-- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {    
+- (void)application:(UIApplication *)application firebaseCloudMessagingDidReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+    [self application:application firebaseCloudMessagingDidReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
+    
     (void)[FirebaseMessagingApplicationDelegate.shared application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
+}
+
+- (void)application:(UIApplication *)application firebaseCloudMessagingdidRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+    [self application:application firebaseCloudMessagingdidRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+    
+    (void)[FirebaseMessagingApplicationDelegate.shared application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
 
 @end

--- a/src/ios/FirebaseMessagingController.swift
+++ b/src/ios/FirebaseMessagingController.swift
@@ -58,9 +58,9 @@ open class FirebaseMessagingController: NSObject {
     }
     
     // MARK: Token Public Methods
-    public func getToken() async {
+    public func getToken(ofType type: OSFCMTokenType = .fcm) async {
         do {
-            let token = try await self.firebaseManager?.getToken() ?? ""
+            let token = try await self.firebaseManager?.getToken(of: type) ?? ""
             let topic = self.firebaseManager?.getGeneralTopic() ?? ""
             try await self.subscribe(topic, token: token)
         } catch let error as FirebaseMessagingErrors {

--- a/src/ios/Managers/MessagingManager.swift
+++ b/src/ios/Managers/MessagingManager.swift
@@ -17,10 +17,24 @@ public class MessagingManager: MessagingProtocol {
         return "\(FirebaseApp.app()?.options.gcmSenderID ?? "")\(Self.generalTopic)"
     }
     
-    /// Returns the Firebase Cloud Messaging registration token. This token is obtained asynchronously.
+    /// Returns the token associated to the parameter `type`.
+    /// If `fcm` it returns the Firebase Cloud Messaging registration token.
+    /// If `apns` it returns  the Apple Push Notification service token.
+    ///  This token is obtained asynchronously.
     /// - Returns: Registration token.
-    public func getToken() async throws -> String {
-        return try await Messaging.messaging().token()
+    /// - Parameter type: type of token to return. Can be `FCM` or `APNs`.
+    public func getToken(of type: OSFCMTokenType) async throws -> String {
+        var result: String
+        let messagingInstance = Messaging.messaging()
+        
+        if type == .apns {
+            guard let data = messagingInstance.apnsToken else { throw FirebaseMessagingErrors.obtainingTokenError }
+            result = data.map{ String(format: "%02.2hhx", $0) }.joined()
+        } else {
+            result = try await messagingInstance.token()
+        }
+        
+        return result
     }
     
     /// Deletes the Firebase cloud Messaging registration token. The deletion is made asynchronously.

--- a/src/ios/OSFirebaseCloudMessaging.swift
+++ b/src/ios/OSFirebaseCloudMessaging.swift
@@ -64,7 +64,15 @@ class OSFirebaseCloudMessaging: CDVPlugin {
     func getToken(command: CDVInvokedUrlCommand) {
         self.callbackId = command.callbackId
         Task {
-            await self.plugin?.getToken()
+            await self.plugin?.getToken(ofType: .fcm)
+        }
+    }
+
+    @objc(getAPNsToken:)
+    func getAPNsToken(command: CDVInvokedUrlCommand) {
+        self.callbackId = command.callbackId
+        Task {
+            await self.plugin?.getToken(ofType: .apns)
         }
     }
     

--- a/src/ios/Protocols/MessagingProtocol.swift
+++ b/src/ios/Protocols/MessagingProtocol.swift
@@ -4,9 +4,13 @@ public protocol MessagingProtocol {
     /// - Returns: Main topic.
     func getGeneralTopic() -> String
     
-    /// Returns the Firebase Cloud Messaging registration token. This token is obtained asynchronously.
+    /// Returns the token associated to the parameter `type`.
+    /// If `fcm` it returns the Firebase Cloud Messaging registration token.
+    /// If `apns` it returns  the Apple Push Notification service token.
+    ///  This token is obtained asynchronously.
     /// - Returns: Registration token.
-    func getToken() async throws -> String
+    /// - Parameter type: type of token to return. Can be `FCM` or `APNs`.
+    func getToken(of type: OSFCMTokenType) async throws -> String
     
     /// Deletes the Firebase cloud Messaging registration token. The deletion is made asynchronously.
     func deleteToken() async throws

--- a/src/ios/Utils/OSFCMTokenType.swift
+++ b/src/ios/Utils/OSFCMTokenType.swift
@@ -1,0 +1,5 @@
+/// Indicates the type of token to be requested
+public enum OSFCMTokenType {
+    case fcm
+    case apns
+}

--- a/www/OSFirebaseCloudMessaging.js
+++ b/www/OSFirebaseCloudMessaging.js
@@ -4,6 +4,10 @@ exports.getToken = function (success, error) {
     exec(success, error, 'OSFirebaseCloudMessaging', 'getToken');
 };
 
+exports.getAPNsToken = function (success, error) {
+    exec(success, error, 'OSFirebaseCloudMessaging', 'getAPNsToken');
+};
+
 exports.subscribe = function (topic, success, error) {
     exec(success, error, 'OSFirebaseCloudMessaging', 'subscribe', [topic]);
 };


### PR DESCRIPTION
## Description
- Update iOS lib files in order to include the new Get APNs Token method, originated from [this PR](https://github.com/OutSystems/OSFirebaseMessagingLib-iOS/pull/11).
- Delegate the app's `application:didRegisterForRemoteNotificationWithDeviceToken:` to Cloud Messaging's delegate extension.

A sample app was generated in order to test the feature and can be checked here: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=2803c12ce5a11cfb5d6c022b51ab7da271ede0f4

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2054

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [x] JavaScript

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
