### PR TITLE
RPM-3590 ::: iOS ::: Silent Notifications Not Triggered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### 26-01-2023
+- Fix: [iOS] Silent Notifications not being triggered. (https://outsystemsrd.atlassian.net/browse/RPM-3590).
+
+## [Version 1.1.0]
+
 ### 21-12-2022
 - Fix: [Android] Fixes clicking a notification without deeplink, when app in foreground (https://outsystemsrd.atlassian.net/browse/RMET-2114)
 

--- a/src/ios/AppDelegate+OSFirebaseCloudMessaging.m
+++ b/src/ios/AppDelegate+OSFirebaseCloudMessaging.m
@@ -8,14 +8,6 @@
     Method original = class_getInstanceMethod(self, @selector(application:didFinishLaunchingWithOptions:));
     Method swizzled = class_getInstanceMethod(self, @selector(application:firebaseCloudMessagingPluginDidFinishLaunchingWithOptions:));
     method_exchangeImplementations(original, swizzled);
-    
-    original = class_getInstanceMethod(self, @selector(application:didReceiveRemoteNotification:fetchCompletionHandler:));
-    swizzled = class_getInstanceMethod(self, @selector(application:firebaseCloudMessagingDidReceiveRemoteNotification:fetchCompletionHandler:));
-    method_exchangeImplementations(original, swizzled);
-    
-    original = class_getInstanceMethod(self, @selector(application:didRegisterForRemoteNotificationsWithDeviceToken:));
-    swizzled = class_getInstanceMethod(self, @selector(application:firebaseCloudMessagingdidRegisterForRemoteNotificationsWithDeviceToken:));
-    method_exchangeImplementations(original, swizzled);
 }
 
 - (BOOL)application:(UIApplication *)application firebaseCloudMessagingPluginDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
@@ -26,15 +18,11 @@
     return YES;
 }
 
-- (void)application:(UIApplication *)application firebaseCloudMessagingDidReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
-    [self application:application firebaseCloudMessagingDidReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
-    
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
     (void)[FirebaseMessagingApplicationDelegate.shared application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
 }
 
-- (void)application:(UIApplication *)application firebaseCloudMessagingdidRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
-    [self application:application firebaseCloudMessagingdidRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
-    
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
     (void)[FirebaseMessagingApplicationDelegate.shared application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
 


### PR DESCRIPTION
## Description
- The method `application:didReceiveRemoteNotification:fetchCompletionHandler:` is not being triggered by apps that use the plugin, so it's not possible to trigger silent notifications. 
- The same fix was applied for the `application:didRegisterForRemoteNotificationsWithDeviceToken:` as the method has currently the same issue.

The following Sample App build was generated to test the fix: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=66830d6777a752adbb192b48007e8728aa6450f8.

## Context
https://outsystemsrd.atlassian.net/browse/RPM-3590

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
