### PR TITLE
RMET-2312 :: Empty silent notification crash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 23-02-2023
+- Fix: Android - Add a guard to deal with cases when there's no data in the extras map (https://outsystemsrd.atlassian.net/browse/RMET-2312)
+
 ### 10-02-2023
 - Feat: [iOS] Make library available as `xcframework` (https://outsystemsrd.atlassian.net/browse/RMET-2280).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.firebase.cloudmessaging",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Outsystems plugin for Firebase Cloud Messaging",
   "keywords": [
     "ecosystem:cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin id="com.outsystems.firebase.cloudmessaging" version="1.0.5" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.firebase.cloudmessaging" version="1.0.6" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   <name>OSFirebaseCloudMessaging</name>
   <description>Outsystems plugin for Firebase Cloud Messaging</description>
   <author>OutSystems Inc</author>

--- a/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
+++ b/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
-    implementation("com.github.outsystems:osfirebasemessaging-android:1.0.1@aar")
+    implementation("com.github.outsystems:osfirebasemessaging-android:1.0.2@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
 
     implementation("com.google.code.gson:gson:2.8.9")


### PR DESCRIPTION
## Description
Applies fixes for Android  crash in silent notifications when there a

## Context
https://github.com/OutSystems/OSFirebaseMessagingLib-Android/pull/25
https://outsystemsrd.atlassian.net/browse/RMET-2312

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
