### PR TITLE
RMET-2310 FB Cloud Messaging - Update FCM lib and add Local Notifications Lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 07-03-2023
+- Feat: [Android] Use `OSLocalNotificationsLib` to trigger a local notification immediately (https://outsystemsrd.atlassian.net/browse/RMET-2310).
+
 ## 03-03-2023
 - Feat: [iOS] Use `OSLocalNotificationsLib` to trigger a local notification immediately (https://outsystemsrd.atlassian.net/browse/RMET-2311).
 

--- a/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
+++ b/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
     implementation("com.github.outsystems:osfirebasemessaging-android:1.0.2.1@aar")
+    implementation("com.github.outsystems:oslocalnotifications-android:0.0.2@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
 
     implementation("com.google.code.gson:gson:2.8.9")

--- a/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
+++ b/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
-    implementation("com.github.outsystems:osfirebasemessaging-android:1.0.2@aar")
+    implementation("com.github.outsystems:osfirebasemessaging-android:1.0.2.1@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
 
     implementation("com.google.code.gson:gson:2.8.9")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR updates the dependency to the FCM Android lib
- Also, it adds a dependency to the Local Notifications Android lib. This is necessary to avoid a runtime exception (`ClassNotFoundException`)

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-2310

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested MABS 8 and 9 builds, and on a Pixel 3XL device running Android 12.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
