### PR TITLE
RMET-2406 ::: Android ::: Remove allowBackup property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 29-03-2023
+- Fix: [Android] - Removed allowBackup property from android lib manifest. (https://outsystemsrd.atlassian.net/browse/RMET-2406)
+
 ## 23-02-2023
-- Fix: Android - Add a guard to deal with cases when there's no data in the extras map (https://outsystemsrd.atlassian.net/browse/RMET-2312)
+- Fix: [Android] - Add a guard to deal with cases when there's no data in the extras map (https://outsystemsrd.atlassian.net/browse/RMET-2312)
 
 ### 10-02-2023
 - Feat: [iOS] Make library available as `xcframework` (https://outsystemsrd.atlassian.net/browse/RMET-2280).

--- a/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
+++ b/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
-    implementation("com.github.outsystems:osfirebasemessaging-android:1.0.2@aar")
+    implementation("com.github.outsystems:osfirebasemessaging-android:1.0.3@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
 
     implementation("com.google.code.gson:gson:2.8.9")


### PR DESCRIPTION
## Description
- Removes `allowBackup` property from AndroidManifest because its value was interfering with other libraries. This causes a security hotspot because `allowBackup` is set to `true` by default and  is good practice to set it explicitly.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2406
https://outsystemsrd.atlassian.net/browse/RPM-3865

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
Tested on support's sandbox test app.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
