### PR TITLE
RMET-2390 ::: iOS ::: External App Authorisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The changes documented here do not include those from the original repository.
 ## [Unreleased]
 
 ## 08-05-2023
+- Feat: [iOS] External App Authorisation (https://outsystemsrd.atlassian.net/browse/RMET-2390).
 - Feat: [iOS] React to the Web Route Event (https://outsystemsrd.atlassian.net/browse/RMET-2394).
 - Feat: [Android] Fix hook for sounds (https://outsystemsrd.atlassian.net/browse/RMET-2215).
 

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -1,0 +1,36 @@
+const et = require('elementtree');
+const path = require('path');
+const fs = require('fs');
+const plist = require('plist');
+const child_process = require('child_process');
+const { ConfigParser } = require('cordova-common');
+const { Console } = require('console');
+
+module.exports = function (context) {
+    var projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
+
+    let configPath = path.join(projectRoot, 'config.xml');
+    let configParser = new ConfigParser(configPath);
+
+    let appName = configParser.name();
+    let applicationSchemes = configParser.getPreference("APPLICATION_SCHEMES", "ios");
+
+    if (applicationSchemes != null && applicationSchemes !== "") {
+        let applicationQueriesSchemes = applicationSchemes.split(",");
+
+        let platformPath = path.join(projectRoot, 'platforms/ios');
+
+        //Change info.plist
+        let infoPlistPath = path.join(platformPath, appName + '/'+ appName +'-info.plist');
+        let infoPlistFile = fs.readFileSync(infoPlistPath, 'utf8');
+        var infoPlist = plist.parse(infoPlistFile);
+
+        let currentValue = infoPlist['LSApplicationQueriesSchemes'];
+        if (currentValue != null && currentValue.length > 0) {
+            applicationQueriesSchemes = currentValue.concat(applicationQueriesSchemes);
+        }
+        infoPlist['LSApplicationQueriesSchemes'] = applicationQueriesSchemes;
+
+        fs.writeFileSync(infoPlistPath, plist.build(infoPlist, { indent: '\t' }));
+    }
+};

--- a/plugin.xml
+++ b/plugin.xml
@@ -43,6 +43,9 @@
 
     <dependency id="cordova-plugin-add-swift-support" url="https://github.com/OutSystems/cordova-plugin-add-swift-support.git#2.0.3-OS1"/>
 
+    <!-- Hooks -->
+    <hook type="after_prepare" src="hooks/ios/iOSCopyPreferences.js" />
+
     <podspec>
         <config>
             <source url="https://cdn.cocoapods.org/"/>


### PR DESCRIPTION
## Description
Add to `plugin.xml` a new hook that reads Extensibility Configurations' `APPLICATION_SCHEMES` preference value, and adds it to `Info.plist`'s `LSApplicationQueriesSchemes` property.

A sample app build on the 2 latest MABS versions was generated in order to test the implementation. We can get it through the following links:
- 8.1 (contains `APPLICATION_SCHEMES`): https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=8172c5a321d104f67d5193253c95e06b05d66553
- 9.0 (doesn't contain the `APPLICATION_SCHEMES`): https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=7c4f4010c0acd877b5fffd5983fe6e394f61af8a

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2390

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [x] JavaScript

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
