### PR TITLE
RMET-3013 FCM Plugin - Anroid - Only handle FCM intents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+- Fix: Only deal with intents from the plugin  (https://outsystemsrd.atlassian.net/browse/RMET-3013)
+
 ## [Version 2.0.0]
 - Feat: update sound hook to unzip sound files, for both iOS and Android (https://outsystemsrd.atlassian.net/browse/RMET-2464).
 - Feat: update firebase core version (https://outsystemsrd.atlassian.net/browse/RMET-2451).

--- a/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
+++ b/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
@@ -66,9 +66,9 @@ class OSFirebaseCloudMessaging : CordovaImplementation() {
         // Check if intent comes from an FCM notification. If not, we don't want to handle it
         // This is necessary so that we don't mistakenly deal with deep links thinking they're FCM notification clicks
         val googleMessageId = extras?.getString(GOOGLE_MESSAGE_ID) // for notifications automatically delivered by the FCM SDK
-        val fcmInternal = extras?.getBoolean(FCM_EXPLICIT_NOTIFICATION) // for notifications that we explicitly deliver in the FCM plugin
+        val fcmInternal = extras?.getString(FCM_EXPLICIT_NOTIFICATION) // for notifications that we explicitly deliver in the FCM plugin
 
-        if (googleMessageId.isNullOrEmpty() && (fcmInternal == false || fcmInternal == null)) {
+        if (googleMessageId.isNullOrEmpty() && fcmInternal.isNullOrEmpty()) {
             return
         }
 

--- a/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
+++ b/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
@@ -37,6 +37,8 @@ class OSFirebaseCloudMessaging : CordovaImplementation() {
         private const val ERROR_FORMAT_PREFIX = "OS-PLUG-FCMS-"
         private const val NOTIFICATION_PERMISSION_REQUEST_CODE = 123123
         private const val NOTIFICATION_PERMISSION_SEND_LOCAL_REQUEST_CODE = 987987
+        const val FCM_EXPLICIT_NOTIFICATION = "fcm_explicit_notification"
+        const val GOOGLE_MESSAGE_ID = "google.message_id"
     }
 
     override fun initialize(cordova: CordovaInterface, webView: CordovaWebView) {
@@ -60,8 +62,18 @@ class OSFirebaseCloudMessaging : CordovaImplementation() {
     private fun handleIntent(intent: Intent) {
         val extras = intent.extras
         val extrasSize = extras?.size() ?: 0
+
+        // Check if intent comes from an FCM notification. If not, we don't want to handle it
+        // This is necessary so that we don't mistakenly deal with deep links thinking they're FCM notification clicks
+        val googleMessageId = extras?.getString(GOOGLE_MESSAGE_ID) // for notifications automatically delivered by the FCM SDK
+        val fcmInternal = extras?.getBoolean(FCM_EXPLICIT_NOTIFICATION) // for notifications that we explicitly deliver in the FCM plugin
+
+        if (googleMessageId.isNullOrEmpty() && (fcmInternal == false || fcmInternal == null)) {
+            return
+        }
+
         if(extrasSize > 0) {
-            val scheme = extras?.getString(FirebaseMessagingOnActionClickActivity.ACTION_DEEP_LINK_SCHEME)
+            val scheme = extras.getString(FirebaseMessagingOnActionClickActivity.ACTION_DEEP_LINK_SCHEME)
             if (scheme.isNullOrEmpty()) {
                 FirebaseMessagingOnClickActivity.notifyClickNotification(intent)
             }

--- a/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
+++ b/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
@@ -37,7 +37,7 @@ class OSFirebaseCloudMessaging : CordovaImplementation() {
         private const val ERROR_FORMAT_PREFIX = "OS-PLUG-FCMS-"
         private const val NOTIFICATION_PERMISSION_REQUEST_CODE = 123123
         private const val NOTIFICATION_PERMISSION_SEND_LOCAL_REQUEST_CODE = 987987
-        const val FCM_EXPLICIT_NOTIFICATION = "fcm_explicit_notification"
+        const val FCM_EXPLICIT_NOTIFICATION = "com.outsystems.fcm.notification"
         const val GOOGLE_MESSAGE_ID = "google.message_id"
     }
 

--- a/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
+++ b/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
-    implementation("com.github.outsystems:osfirebasemessaging-android:1.1.3@aar")
+    implementation("com.github.outsystems:osfirebasemessaging-android:1.1.5@aar")
     implementation("com.github.outsystems:oslocalnotifications-android:1.0.0@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR includes a fix in the `handleIntent` method to only handle intents that come from our FCM plugin (through a notification click).

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
- This is necessary so that the plugin, when dealing with an incoming `intent`, can identify if the `intent` comes from a FCM notification. If not, then the plugin should do nothing.
- When other intents open the app (e.g. deep links), the FCM plugin should not handle them.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

- Tested with MABS 9 build in device with Android 14.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
