### PR TITLE
RMET-3315 :: Hook :: ODC :: Sound as a resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+- Feat: Deal with `sounds` as a resource in ODC. (https://outsystemsrd.atlassian.net/browse/RMET-3315)
 - Fix: Make `cleanUp` hook only run after all sound files are copied successfully. (https://outsystemsrd.atlassian.net/browse/RMET-3326)
 - Chore: Update cordova hooks with new OutSystems specific errors. (https://outsystemsrd.atlassian.net/browse/RMET-3302)
 - Chore: Update `FirebaseMessaging` iOS pod to version `10.23.0`. This includes the Privacy Manifest (https://outsystemsrd.atlassian.net/browse/RMET-3274).

--- a/hooks/unzipSound.js
+++ b/hooks/unzipSound.js
@@ -62,35 +62,24 @@ module.exports = function(context) {
   let soundFolderPath = platformConfig.getSoundDestinationFolder();
   soundFolderPath = path.join(context.opts.projectRoot, soundFolderPath);
 
-  let soundZipFile = path.join(sourcePath, constants.soundZipFile);
+  let zipFile = utils.getFileName(sourcePath, "sounds", ".zip");
+  
   let promises = [];
-  if(utils.checkIfFileOrFolderExists(soundZipFile)){
-    let zip = new AdmZip(soundZipFile);
-    zip.extractAllTo(sourcePath, true);
+  
+  if(zipFile != ""){
+    let soundZipFilePath = path.join(sourcePath, zipFile);
+    let zip = new AdmZip(soundZipFilePath);
+    let zipFolder = sourcePath + "/sounds"
+    zip.extractAllTo(zipFolder, true);
     
     let entriesNr = zip.getEntries().length;
     console.log(`FCM_LOG: Sound zip file has ${entriesNr} entries`);
     if(entriesNr == 0) {
       throw new Error (`OUTSYSTEMS_PLUGIN_ERROR: Sound zip file is empty, either delete it or add one or more files.`)
     }
-  
-    let zipFolder = sourcePath + "/sounds"
     
-    if(!utils.checkIfFileOrFolderExists(zipFolder)){
-      console.log(`FCM_LOG: No new folder unzipping.`)
-      /**
-       * to deal with the following case:
-       * iOS + one file in zip + O11
-      **/
-      if(sourcePath != soundFolderPath){
-        console.log(`FCM_LOG: ${sourcePath} != ${soundFolderPath} so we need to copy files.`)
-        promises = copyWavFiles(platformConfig, sourcePath, soundFolderPath, defer)
-      } else {
-        console.log(`FCM_LOG: ${sourcePath} == ${soundFolderPath} so we don't need to copy files.`)
-      }
-    } else { 
-      promises = copyWavFiles(platformConfig, zipFolder, soundFolderPath, defer)  
-    }
+   promises = copyWavFiles(platformConfig, zipFolder, soundFolderPath, defer)  
+   
   }
   return promises.length > 0 ? q.all(promises) : defer.resolve();
 }

--- a/hooks/utilities.js
+++ b/hooks/utilities.js
@@ -69,22 +69,7 @@ function getPlatformConfigs(platform) {
 
 function getPlatformSoundPath(context, platformConfig){
   let projectRoot = context.opts.projectRoot;
-  let platformPath;
-
-  /**
-  if(platformConfig === constants.android){
-    platformPath = path.join(projectRoot, `platforms/android/www`);
-  } else {
-    let appName = getAppName(context)
-    platformPath = path.join(projectRoot, `platforms/ios/${appName}/Resources/www`);   
-  }
-      
-  if(!fs.existsSync(platformPath)){
-     */
-    platformPath = path.join(projectRoot, platformConfig.getWWWFolder());
- // }
-  
-  return platformPath
+  return  path.join(projectRoot, platformConfig.getWWWFolder());
 }
 
 function isCordovaAbove(context, version) {

--- a/hooks/utilities.js
+++ b/hooks/utilities.js
@@ -13,7 +13,7 @@ var constants = {
       return "platforms/android/app/src/main/res/raw";
     },
     getWWWFolder: function() {
-      return "www";
+      return "platforms/android/app/src/main/assets/www";
     }
   },
   ios: {
@@ -31,6 +31,14 @@ var constants = {
 
 function checkIfFileOrFolderExists(path) {
   return fs.existsSync(path);
+}
+
+
+function getFileName(dir, searchString, withExtension){
+  const files = fs.readdirSync(dir);
+  const matchingFiles = files.filter(file => file.includes(searchString) && file.endsWith(withExtension));
+  // return true if there are matching files, false otherwise
+  return matchingFiles.length > 0 ?matchingFiles[0] : "";
 }
 
 function removeFile(path){
@@ -63,6 +71,7 @@ function getPlatformSoundPath(context, platformConfig){
   let projectRoot = context.opts.projectRoot;
   let platformPath;
 
+  /**
   if(platformConfig === constants.android){
     platformPath = path.join(projectRoot, `platforms/android/www`);
   } else {
@@ -71,8 +80,9 @@ function getPlatformSoundPath(context, platformConfig){
   }
       
   if(!fs.existsSync(platformPath)){
+     */
     platformPath = path.join(projectRoot, platformConfig.getWWWFolder());
-  }
+ // }
   
   return platformPath
 }
@@ -116,5 +126,6 @@ module.exports = {
   removeFolder,
   isAndroid,
   getAppName,
-  getPlatformSoundPath
+  getPlatformSoundPath,
+  getFileName
 };


### PR DESCRIPTION
## Description
-  no longer assumes the zip file to be exact and that it's placed in platform's `www` resource folder
- unzips files to a specific folder before copying them

## Context
This PR assumes the `sounds.zip` file is treated as a resource on ODC (new) and O11. 
For O11, nothing changes, as it was already a resource. However, for ODC builds, this means the file name won't be exactly `sounds.zip` >> it bill be `sounds__[hash].zip`.

For why, check the [JIRA issue](https://outsystemsrd.atlassian.net/browse/RMET-3315)

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [x] Breaking change **for ODC**(change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [x] JavaScript


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
