### PR TITLE
RMET-3508 ::: Android ::: Remove Main Thread Block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The changes documented here do not include those from the original repository.
 ### Features
 - Enable message delivery metrics exportation to BigQuery (https://outsystemsrd.atlassian.net/browse/RMET-3511).
 
+### Fixes
+- Remove the main thread blocking (https://outsystemsrd.atlassian.net/browse/RMET-3508).
+
 ## [Version 2.2.1]
 
 ### 03-06-2024

--- a/plugin.xml
+++ b/plugin.xml
@@ -85,6 +85,7 @@
       <string name="notification_channel_description">Channel description</string>
     </config-file>
 
+    <source-file src="src/android/com/outsystems/firebase/cloudmessaging/OSFCMPermissionEvents.kt" target-dir="app/src/main/kotlin/com/outsystems/firebase/cloudmessaging"/>
     <source-file src="src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt" target-dir="app/src/main/kotlin/com/outsystems/firebase/cloudmessaging"/>
     <framework src="src/android/com/outsystems/firebase/cloudmessaging/build.gradle" custom="true" type="gradleReference" />
 

--- a/src/android/com/outsystems/firebase/cloudmessaging/OSFCMPermissionEvents.kt
+++ b/src/android/com/outsystems/firebase/cloudmessaging/OSFCMPermissionEvents.kt
@@ -1,0 +1,6 @@
+package com.outsystems.firebase.cloudmessaging
+
+sealed class OSFCMPermissionEvents {
+    data object Granted: OSFCMPermissionEvents()
+    data object NotGranted: OSFCMPermissionEvents()
+}

--- a/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
+++ b/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
@@ -1,5 +1,6 @@
 package com.outsystems.firebase.cloudmessaging
 
+import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -44,7 +45,6 @@ class OSFirebaseCloudMessaging : CordovaImplementation() {
         private const val NOTIFICATION_PERMISSION_REQUEST_CODE = 123123
         const val FCM_EXPLICIT_NOTIFICATION = "com.outsystems.fcm.notification"
         const val GOOGLE_MESSAGE_ID = "google.message_id"
-        const val POST_NOTIFICATIONS_PERMISSION = "android.permission.POST_NOTIFICATIONS"
     }
 
     override fun initialize(cordova: CordovaInterface, webView: CordovaWebView) {
@@ -259,11 +259,11 @@ class OSFirebaseCloudMessaging : CordovaImplementation() {
         flow = MutableSharedFlow(replay = 1)
 
         // if it doesn't have permission, request it
-        val hasPermission = checkPermission(POST_NOTIFICATIONS_PERMISSION)
+        val hasPermission = checkPermission(Manifest.permission.POST_NOTIFICATIONS)
         if (hasPermission) {
             flow?.emit(OSFCMPermissionEvents.Granted)
         } else {
-            requestPermission(NOTIFICATION_PERMISSION_REQUEST_CODE, POST_NOTIFICATIONS_PERMISSION)
+            requestPermission(NOTIFICATION_PERMISSION_REQUEST_CODE, Manifest.permission.POST_NOTIFICATIONS)
         }
 
         flow?.collect {

--- a/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
+++ b/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
@@ -1,23 +1,26 @@
-package com.outsystems.firebase.cloudmessaging;
+package com.outsystems.firebase.cloudmessaging
 
 import android.content.Context
 import android.content.Intent
-import android.os.Build
-import androidx.core.content.PermissionChecker.PERMISSION_GRANTED
-import androidx.core.content.PermissionChecker.PermissionResult
-import com.outsystems.osnotificationpermissions.OSNotificationPermissions
+import android.content.pm.PackageManager
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import com.outsystems.plugins.firebasemessaging.controller.*
 import com.outsystems.plugins.firebasemessaging.model.FirebaseMessagingError
 import com.outsystems.plugins.firebasemessaging.model.database.DatabaseManager
 import com.outsystems.plugins.firebasemessaging.model.database.DatabaseManagerInterface
 import com.outsystems.plugins.oscordova.CordovaImplementation
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
 import org.apache.cordova.CallbackContext
 import org.apache.cordova.CordovaInterface
 import org.apache.cordova.CordovaWebView
+import org.apache.cordova.PluginResult
+import org.apache.cordova.PluginResult.Status
 import org.json.JSONArray
-
+import org.json.JSONObject
 
 class OSFirebaseCloudMessaging : CordovaImplementation() {
 
@@ -29,16 +32,19 @@ class OSFirebaseCloudMessaging : CordovaImplementation() {
 
     private var deviceReady: Boolean = false
     private val eventQueue: MutableList<String> = mutableListOf()
-    private var notificationPermission = OSNotificationPermissions()
+
+    private val gson: Gson = GsonBuilder().excludeFieldsWithoutExposeAnnotation().create()
+
+    private var flow: MutableSharedFlow<OSFCMPermissionEvents>? = null
 
     companion object {
         private const val CHANNEL_NAME_KEY = "notification_channel_name"
         private const val CHANNEL_DESCRIPTION_KEY = "notification_channel_description"
         private const val ERROR_FORMAT_PREFIX = "OS-PLUG-FCMS-"
         private const val NOTIFICATION_PERMISSION_REQUEST_CODE = 123123
-        private const val NOTIFICATION_PERMISSION_SEND_LOCAL_REQUEST_CODE = 987987
         const val FCM_EXPLICIT_NOTIFICATION = "com.outsystems.fcm.notification"
         const val GOOGLE_MESSAGE_ID = "google.message_id"
+        const val POST_NOTIFICATIONS_PERMISSION = "android.permission.POST_NOTIFICATIONS"
     }
 
     override fun initialize(cordova: CordovaInterface, webView: CordovaWebView) {
@@ -114,83 +120,132 @@ class OSFirebaseCloudMessaging : CordovaImplementation() {
             triggerEvent(event)
         }
         eventQueue.clear()
-
-        if(Build.VERSION.SDK_INT >= 33 &&
-            !notificationPermission.hasNotificationPermission(this)) {
-
-            notificationPermission.requestNotificationPermission(
-                this,
-                NOTIFICATION_PERMISSION_SEND_LOCAL_REQUEST_CODE)
-        }
-
     }
 
-    override fun execute(action: String, args: JSONArray, callbackContext: CallbackContext): Boolean {
-        this.callbackContext = callbackContext
-        val result = runBlocking {
+    override fun execute(
+        action: String,
+        args: JSONArray,
+        callbackContext: CallbackContext
+    ): Boolean {
+        CoroutineScope(IO).launch {
             when (action) {
                 "ready" -> {
                     ready()
                 }
+
                 "getToken" -> {
-                    controller.getToken()
+                    getToken(callbackContext)
                 }
+
                 "subscribe" -> {
-                    args.getString(0)?.let { topic ->
-                        controller.subscribe(topic)
+                    args.getString(0)?.let {
+                        topicOperation(
+                            callbackContext,
+                            operation = {
+                                controller.subscribe(it)
+                            },
+                            FirebaseMessagingError.SUBSCRIPTION_ERROR
+                        )
                     }
                 }
+
                 "unsubscribe" -> {
-                    args.getString(0)?.let { topic ->
-                        controller.unsubscribe(topic)
+                    args.getString(0)?.let {
+                        topicOperation(
+                            callbackContext,
+                            operation = {
+                                controller.unsubscribe(it)
+                            },
+                            FirebaseMessagingError.UNSUBSCRIPTION_ERROR
+                        )
                     }
                 }
+
                 "registerDevice" -> {
-                    registerWithPermission()
+                    registerDevice(callbackContext)
                 }
+
                 "unregisterDevice" -> {
-                    controller.unregisterDevice()
+                    unregisterDevice(callbackContext)
                 }
+
                 "clearNotifications" -> {
-                    clearNotifications()
+                    clearNotifications(callbackContext)
                 }
+
                 "sendLocalNotification" -> {
-                    sendLocalNotification(args)
+                    sendLocalNotification(args, callbackContext)
                 }
-                "setBadge" -> {
-                    setBadgeNumber()
-                }
-                "getBadge" -> {
-                    getBadgeNumber()
-                }
+
                 "getPendingNotifications" -> {
-                    args.getBoolean(0).let { clearFromDatabase ->
-                        controller.getPendingNotifications(clearFromDatabase)
-                    }
+                    val clearFromDatabase = args.getBoolean(0)
+                    getPendingNotifications(clearFromDatabase, callbackContext)
                 }
+
                 "setDeliveryMetricsExportToBigQuery" -> {
                     args.getJSONObject(0).getBoolean("enable").let {
-                        controller.setDeliveryMetricsExportToBigQuery(it)
+                        setDeliveryMetricsExportToBigQuery(it, callbackContext)
                     }
                 }
+
                 "deliveryMetricsExportToBigQueryEnabled" -> {
-                    controller.deliveryMetricsExportToBigQueryEnabled()
+                    deliveryMetricsExportToBigQueryEnabled(callbackContext)
                 }
-                else -> false
+
+                // non available methods
+                "setBadge" -> {
+                    sendError(callbackContext, FirebaseMessagingError.SET_BADGE_NOT_AVAILABLE_ERROR)
+                }
+
+                "getBadge" -> {
+                    sendError(callbackContext, FirebaseMessagingError.GET_BADGE_NOT_AVAILABLE_ERROR)
+                }
+
+                "getAPNsToken" -> {
+                    sendError(callbackContext, FirebaseMessagingError.GET_APNS_TOKEN_NOT_AVAILABLE_ERROR)
+                }
             }
-            true
         }
-        return result
+        return true
+    }
+
+    private suspend fun getToken(callbackContext: CallbackContext) {
+        controller.getToken()?.let {
+            sendSuccess(callbackContext, it)
+        } ?: sendError(callbackContext, FirebaseMessagingError.OBTAINING_TOKEN_ERROR)
+    }
+
+    private suspend fun topicOperation(callbackContext: CallbackContext, operation: suspend () -> Boolean, error: FirebaseMessagingError) {
+        if (operation()) {
+            sendSuccess(callbackContext)
+        } else {
+            sendError(callbackContext, error)
+        }
+    }
+
+    private fun getPendingNotifications(clearFromDatabase: Boolean, callbackContext: CallbackContext) {
+        val errorCallback: () -> Unit = {
+            sendError(callbackContext, FirebaseMessagingError.GET_PENDING_NOTIFICATIONS_ERROR)
+        }
+
+        val pendingNotificationNullableList = controller.getPendingNotifications(clearFromDatabase)
+        pendingNotificationNullableList?.let { pendingNotificationList ->
+            gson.toJson(pendingNotificationList)?.let { jsonString ->
+                sendSuccess(callbackContext, jsonString)
+            } ?: errorCallback
+        } ?: errorCallback
     }
 
     override fun onRequestPermissionResult(requestCode: Int,
                                            permissions: Array<String>,
                                            grantResults: IntArray) {
-        when(requestCode) {
-            NOTIFICATION_PERMISSION_REQUEST_CODE -> {
-                CoroutineScope(IO).launch {
-                    controller.registerDevice()
-                }
+        if (requestCode == NOTIFICATION_PERMISSION_REQUEST_CODE) {
+            CoroutineScope(IO).launch {
+                flow?.emit(
+                    if (grantResults.indexOfFirst { it != PackageManager.PERMISSION_GRANTED } == -1)
+                        OSFCMPermissionEvents.Granted
+                    else OSFCMPermissionEvents.NotGranted
+                )
             }
         }
     }
@@ -200,36 +255,70 @@ class OSFirebaseCloudMessaging : CordovaImplementation() {
         return false
     }
 
-    private fun getBadgeNumber() {
-        controller.getBadgeNumber()
+    private suspend fun registerDevice(callbackContext: CallbackContext) {
+        flow = MutableSharedFlow(replay = 1)
+
+        // if it doesn't have permission, request it
+        val hasPermission = checkPermission(POST_NOTIFICATIONS_PERMISSION)
+        if (hasPermission) {
+            flow?.emit(OSFCMPermissionEvents.Granted)
+        } else {
+            requestPermission(NOTIFICATION_PERMISSION_REQUEST_CODE, POST_NOTIFICATIONS_PERMISSION)
+        }
+
+        flow?.collect {
+            if (it == OSFCMPermissionEvents.Granted) {
+                if (controller.registerDevice()) {
+                    sendSuccess(callbackContext)
+                } else {
+                    sendError(callbackContext, FirebaseMessagingError.REGISTRATION_ERROR)
+                }
+            } else {
+                sendError(callbackContext,  FirebaseMessagingError.NOTIFICATIONS_PERMISSIONS_DENIED_ERROR)
+            }
+        }
     }
 
-    private suspend fun registerWithPermission() {
-        val hasPermission = notificationPermission.hasNotificationPermission(this)
-        if(Build.VERSION.SDK_INT < 33 || hasPermission) {
-            controller.registerDevice()
-        }
-        else {
-            notificationPermission
-                .requestNotificationPermission(this, NOTIFICATION_PERMISSION_REQUEST_CODE)
+    private suspend fun unregisterDevice(callbackContext: CallbackContext) {
+        if (controller.unregisterDevice()) {
+            sendSuccess(callbackContext)
+        } else {
+            sendError(callbackContext, FirebaseMessagingError.UNREGISTRATION_ERROR)
         }
     }
 
-    private fun sendLocalNotification(args : JSONArray) {
+    private fun sendLocalNotification(args: JSONArray, callbackContext: CallbackContext) {
         val badge = args.get(0).toString().toInt()
         val title = args.get(1).toString()
         val text = args.get(2).toString()
         val channelName = args.get(3).toString()
         val channelDescription = args.get(4).toString()
-        controller.sendLocalNotification(badge, title, text, null, channelName, channelDescription)
+
+        val result = controller.sendLocalNotification(badge, title, text, null, channelName, channelDescription)
+        if (result.first) {
+            sendSuccess(callbackContext)
+        } else {
+            result.second?.let {
+                sendError(callbackContext, it)
+            }
+        }
     }
 
-    private fun clearNotifications() {
-        controller.clearNotifications()
+    private fun clearNotifications(callbackContext: CallbackContext) {
+        if (controller.clearNotifications()) {
+            sendSuccess(callbackContext)
+        } else {
+            sendError(callbackContext, FirebaseMessagingError.CLEARING_NOTIFICATIONS_ERROR)
+        }
     }
 
-    private fun setBadgeNumber() {
-        controller.setBadgeNumber()
+    private fun setDeliveryMetricsExportToBigQuery(enable: Boolean, callbackContext: CallbackContext) {
+        controller.setDeliveryMetricsExportToBigQuery(enable)
+        sendSuccess(callbackContext)
+    }
+
+    private fun deliveryMetricsExportToBigQueryEnabled(callbackContext: CallbackContext) {
+        sendSuccess(callbackContext, controller.deliveryMetricsExportToBigQueryEnabled().toString())
     }
 
     private fun setupChannelNameAndDescription(){
@@ -256,4 +345,19 @@ class OSFirebaseCloudMessaging : CordovaImplementation() {
         return ERROR_FORMAT_PREFIX + code.toString().padStart(4, '0')
     }
 
+    private fun sendSuccess(callbackContext: CallbackContext, stringValue: String? = null) {
+        val pluginResult = stringValue?.let { PluginResult(Status.OK, it) } ?: PluginResult(Status.OK)
+        callbackContext.sendPluginResult(pluginResult)
+    }
+
+    private fun sendError(callbackContext: CallbackContext, error: FirebaseMessagingError) {
+        val pluginResult = PluginResult(
+            Status.ERROR,
+            JSONObject().apply {
+                put("code", formatErrorCode(error.code))
+                put("message", error.description)
+            }
+        )
+        callbackContext.sendPluginResult(pluginResult)
+    }
 }

--- a/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
+++ b/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
-    implementation("com.github.outsystems:osfirebasemessaging-android:1.2.0-dev1@aar")
+    implementation("com.github.outsystems:osfirebasemessaging-android:1.2.0-dev2@aar")
     implementation("com.github.outsystems:oslocalnotifications-android:1.0.0@aar")
     implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
 

--- a/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
+++ b/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
@@ -25,7 +25,6 @@ dependencies {
     implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
     implementation("com.github.outsystems:osfirebasemessaging-android:1.2.0-dev2@aar")
     implementation("com.github.outsystems:oslocalnotifications-android:1.0.0@aar")
-    implementation("com.github.outsystems:osnotificationpermissions-android:0.0.4@aar")
 
     implementation("com.google.code.gson:gson:2.8.9")
 


### PR DESCRIPTION
## Description
- Update the Android library to [this version](https://github.com/OutSystems/OSFirebaseMessagingLib-Android/pull/57).
- Considering that most library's methods are now returning objects instead of having delegate callbacks, adapt the bridge to it.
- Remove the `runBlocking` block within the `execute` method and use a `CoroutineScope` instead, to not block the main thread.
- Make unsupported methods return a non-supported error immediately.
- Remove the `OSNotificationPermissions` library and do it all within the bridge.
-  Fix the push notification logic, by having a look into the option chosen by the user and react accordingly. This is now managed by a `SharedFlow` object and the `OSFCMPermissionEvents` class used within the Register Device feature.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3508

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
Performed manual testing to check if every feature is working as before.

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
