### PR TITLE
RMET-3540 :: Android :: Update oscordova dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The changes documented here do not include those from the original repository.
 
 ### Fixes
 - Remove the main thread blocking (https://outsystemsrd.atlassian.net/browse/RMET-3508).
+- Update `oscordova` dependency (https://outsystemsrd.atlassian.net/browse/RMET-3540)
 
 ## [Version 2.2.1]
 

--- a/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
+++ b/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
@@ -66,6 +66,10 @@ class OSFirebaseCloudMessaging : CordovaImplementation() {
         handleIntent(intent)
     }
 
+    override fun onResume(multitasking: Boolean) {
+        // Not used in this project.
+    }
+
     private fun handleIntent(intent: Intent) {
         val extras = intent.extras
         val extrasSize = extras?.size() ?: 0

--- a/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
+++ b/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'kotlin-kapt'
 
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
-    implementation("com.github.outsystems:oscordova-android:1.2.0@aar")
+    implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
     implementation("com.github.outsystems:osfirebasemessaging-android:1.2.0-dev2@aar")
     implementation("com.github.outsystems:oslocalnotifications-android:1.0.0@aar")
 


### PR DESCRIPTION
## Description
Currently we're using `oscordova` and `CordovaImplementation` for Android's bridge/plugin class. 
The version the plugin was using was outdated and causing incompatibilities with other plugins, namely plugins with versions `2.0.X`. This PR updates this dependency and its code accordingly.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3540

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
App built with MABS 10 and with the following plugins: Payments, HealthFitness, Camera and Barcode
https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=d7b82849d7ac0989ea2b9c991084390519a79a1a&stg=dev

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
