### PR TITLE
RMET-3511 ::: Android ::: Migrate Room Database to v2

### DIFF
--- a/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
+++ b/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
@@ -237,8 +237,8 @@ class OSFirebaseCloudMessaging : CordovaImplementation() {
         pendingNotificationNullableList?.let { pendingNotificationList ->
             gson.toJson(pendingNotificationList)?.let { jsonString ->
                 sendSuccess(callbackContext, jsonString)
-            } ?: errorCallback
-        } ?: errorCallback
+            } ?: errorCallback()
+        } ?: errorCallback()
     }
 
     override fun onRequestPermissionResult(requestCode: Int,

--- a/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
+++ b/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
-    implementation("com.github.outsystems:osfirebasemessaging-android:1.2.0-dev2@aar")
+    implementation("com.github.outsystems:osfirebasemessaging-android:1.2.0-dev17@aar")
     implementation("com.github.outsystems:oslocalnotifications-android:1.0.0@aar")
 
     implementation("com.google.code.gson:gson:2.8.9")


### PR DESCRIPTION
## Description
This fixes an issue introduced in https://github.com/OutSystems/cordova-outsystems-firebase-cloud-messaging/pull/102:
- Add parenthesis to `errorCallback` to execute the call.
- Update `aar` to use the latest version.

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
To test this, a new version of the Sample App was installed on top of a previous, to validate that the migration was successful.

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
