### PR TITLE
RMET-4277 - Use Set in hook to avoid duplicates in `LSApplicationQueriesSchemes` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+
+### Fix
+
+- (ios) Updates hook to avoid duplicates in `.plist` (https://outsystemsrd.atlassian.net/browse/RMET-4277).
+
 ## [Version 2.5.0]
 
 ### Feature

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -29,7 +29,7 @@ module.exports = function (context) {
         if (currentValue != null && currentValue.length > 0) {
             applicationQueriesSchemes = currentValue.concat(applicationQueriesSchemes);
         }
-        infoPlist['LSApplicationQueriesSchemes'] = applicationQueriesSchemes;
+        infoPlist['LSApplicationQueriesSchemes'] = [...new Set(applicationQueriesSchemes)];
 
         fs.writeFileSync(infoPlistPath, plist.build(infoPlist, { indent: '\t' }));
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Context: In MOCA builds, this hook will run two times, and the query schemes would be duplicated.
- So we use a Set as a way to avoid duplicates.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-4277

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested with MOCA builds in Mobile ALM tenant.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
