### PR TITLE
RMET-4397 - Android - Notification extras not sent when deeplink (screen) wasn't present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The changes documented here do not include those from the original repository.
 
 ### Fix
 
+- (android) Include notification extras in click event even if there is no deeplink (https://outsystemsrd.atlassian.net/browse/RMET-4397).
 - (ios) Updates hook to avoid duplicates in `.plist` (https://outsystemsrd.atlassian.net/browse/RMET-4277).
 
 ## [Version 2.5.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
-## [Unreleased]
+## [2.5.1]
 
 ### Fix
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.firebase.cloudmessaging",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Outsystems plugin for Firebase Cloud Messaging",
   "keywords": [
     "ecosystem:cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin id="com.outsystems.firebase.cloudmessaging" version="2.5.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.firebase.cloudmessaging" version="2.5.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 
   <name>OSFirebaseCloudMessaging</name>
   <description>Outsystems plugin for Firebase Cloud Messaging</description>

--- a/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
+++ b/src/android/com/outsystems/firebase/cloudmessaging/build.gradle
@@ -23,8 +23,8 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
-    implementation("com.github.outsystems:osfirebasemessaging-android:1.3.0@aar")
-    implementation("com.github.outsystems:oslocalnotifications-android:1.1.0@aar")
+    implementation("com.github.outsystems:osfirebasemessaging-android:1.3.1-dev@aar")
+    implementation("com.github.outsystems:oslocalnotifications-android:1.1.1-dev@aar")
 
     implementation("com.google.code.gson:gson:2.8.9")
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Updates dependency to `OSFirebaseMessagingLib-Android` to bring fix from https://github.com/OutSystems/OSFirebaseMessagingLib-Android/pull/71
- Also updates dependency to `OSLocalNotificationsLib-Android` 

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-4397

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested in Pixel 7 and Pixel 9 Pro with Android 16.

MABS 12 build - Use latest build of the Firebase Sample App on our ODC tenant

[MABS 11 build](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=077b38a7a7d79f3847faebdae1188404e8261951&stg=prd)

[MABS 10 build](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=0487a5b78861612208945c57f78a71f37ed8c090&stg=prd)

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
