### PR TITLE
fix(android): handle errors in RegisterDevice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+### [2.5.6]
+
+### Fixes
+
+- (android) Handle errors in `RegisterDevice` instead of hanging indefinitely (https://outsystemsrd.atlassian.net/browse/RMET-4953)
+
 ### [2.5.5]
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.firebase.cloudmessaging",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "Outsystems plugin for Firebase Cloud Messaging",
   "keywords": [
     "ecosystem:cordova",
@@ -19,5 +19,5 @@
   },
   "dependencies": {
     "adm-zip": "0.5.12"
-  } 
+  }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin id="com.outsystems.firebase.cloudmessaging" version="2.5.5" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.firebase.cloudmessaging" version="2.5.6" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 
   <name>OSFirebaseCloudMessaging</name>
   <description>Outsystems plugin for Firebase Cloud Messaging</description>

--- a/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
+++ b/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
@@ -260,24 +260,26 @@ class OSFirebaseCloudMessaging : CordovaPlugin() {
     }
 
     private suspend fun registerDevice(callbackContext: CallbackContext) {
-        flow = MutableSharedFlow(replay = 1)
+        try {
+            flow = MutableSharedFlow(replay = 1)
 
-        // for build versions from Tiramisu, if it doesn't have permission, request it
-        // for older build versions, the permission is given by default
-        val hasPermission = Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || 
-                PermissionHelper.hasPermission(this, Manifest.permission.POST_NOTIFICATIONS)
-        if (hasPermission) {
-            flow?.emit(OSFCMPermissionEvents.Granted)
-        } else {
-            PermissionHelper.requestPermission(
-                this,
-                NOTIFICATION_PERMISSION_REQUEST_CODE,
-                Manifest.permission.POST_NOTIFICATIONS
-            )
-        }
+            // for build versions from Tiramisu, if it doesn't have permission, request it
+            // for older build versions, the permission is given by default
+            val hasPermission = Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || 
+                    PermissionHelper.hasPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+            if (hasPermission) {
+                flow?.emit(OSFCMPermissionEvents.Granted)
+            } else {
+                PermissionHelper.requestPermission(
+                    this,
+                    NOTIFICATION_PERMISSION_REQUEST_CODE,
+                    Manifest.permission.POST_NOTIFICATIONS
+                )
+            }
 
-        flow?.collect {
-            if (it == OSFCMPermissionEvents.Granted) {
+            val permissionResult = flow?.first()
+
+            if (permissionResult == OSFCMPermissionEvents.Granted) {
                 if (controller.registerDevice(cordova.context.packageName)) {
                     sendSuccess(callbackContext)
                 } else {
@@ -286,6 +288,8 @@ class OSFirebaseCloudMessaging : CordovaPlugin() {
             } else {
                 sendError(callbackContext,  FirebaseMessagingError.NOTIFICATIONS_PERMISSIONS_DENIED_ERROR)
             }
+        } catch (e: Exception) {
+            sendError(callbackContext, FirebaseMessagingError.REGISTRATION_ERROR)
         }
     }
 

--- a/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
+++ b/src/android/com/outsystems/firebase/cloudmessaging/OSFirebaseCloudMessaging.kt
@@ -15,6 +15,7 @@ import com.outsystems.plugins.firebasemessaging.model.database.DatabaseManagerIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.apache.cordova.CallbackContext
 import org.apache.cordova.CordovaInterface
@@ -261,23 +262,30 @@ class OSFirebaseCloudMessaging : CordovaPlugin() {
 
     private suspend fun registerDevice(callbackContext: CallbackContext) {
         try {
-            flow = MutableSharedFlow(replay = 1)
-
             // for build versions from Tiramisu, if it doesn't have permission, request it
             // for older build versions, the permission is given by default
             val hasPermission = Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || 
                     PermissionHelper.hasPermission(this, Manifest.permission.POST_NOTIFICATIONS)
-            if (hasPermission) {
-                flow?.emit(OSFCMPermissionEvents.Granted)
+            
+            val permissionResult = if (hasPermission) {
+                OSFCMPermissionEvents.Granted
             } else {
-                PermissionHelper.requestPermission(
-                    this,
-                    NOTIFICATION_PERMISSION_REQUEST_CODE,
-                    Manifest.permission.POST_NOTIFICATIONS
-                )
+                // To prevent hanging if registerDevice is called multiple times in quick succession,
+                // we check if a permission request is already in progress.
+                if (flow != null) {
+                    flow?.first()
+                } else {
+                    flow = MutableSharedFlow(replay = 1)
+                    PermissionHelper.requestPermission(
+                        this,
+                        NOTIFICATION_PERMISSION_REQUEST_CODE,
+                        Manifest.permission.POST_NOTIFICATIONS
+                    )
+                    val result = flow?.first()
+                    flow = null
+                    result
+                }
             }
-
-            val permissionResult = flow?.first()
 
             if (permissionResult == OSFCMPermissionEvents.Granted) {
                 if (controller.registerDevice(cordova.context.packageName)) {


### PR DESCRIPTION
## Description
The RegisterDevice method on Android could hang indefinitely due to an infinite `flow.collect` loop and missing error handling for exceptions thrown during the process. This fix replaces `collect` with `first()` for a single execution and adds a `try-catch` block to ensure a result is always returned to the bridge.

## Context
[RMET-4953](https://outsystemsrd.atlassian.net/browse/RMET-4953?atlOrigin=eyJpIjoiODJlYWQwYWE5ZTQ0NGJjNjlmMzlhY2VlNmQ5YTBlNTUiLCJwIjoiaiJ9)

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests
Tested on MABS 12 by force throwing an exception in RegisterDevice to see if it resolved


[RMET-4953]: https://outsystemsrd.atlassian.net/browse/RMET-4953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ